### PR TITLE
#1 Crawl Sakura cards. 

### DIFF
--- a/crawlers/items.py
+++ b/crawlers/items.py
@@ -7,3 +7,11 @@ class ClowCardItem(scrapy.Item):
     sign = scrapy.Field()
     hierarchy = scrapy.Field()
     magic_type = scrapy.Field()
+
+class SakuraCardItem(scrapy.Item):
+    card = scrapy.Field()
+    card_type = scrapy.Field()
+    img_url = scrapy.Field()
+    sign = scrapy.Field()
+    hierarchy = scrapy.Field()
+    magic_type = scrapy.Field()

--- a/crawlers/loaders.py
+++ b/crawlers/loaders.py
@@ -19,3 +19,12 @@ class ClowCardLoader(ItemLoader):
 
     img_url_out = fix_url_field
 
+class SakuraCardLoader(ItemLoader):
+    default_output_processor = TakeFirst()
+
+    card_out = fix_text_field
+    sign_out = fix_text_field
+    hierarchy_out = fix_text_field
+    magic_type_out = fix_text_field
+
+    img_url_out = fix_url_field

--- a/crawlers/spiders/sakura_cards_spider.py
+++ b/crawlers/spiders/sakura_cards_spider.py
@@ -1,0 +1,28 @@
+import scrapy
+
+from crawlers.spiders.selectors import sakura_cards_selectors as ccs
+from crawlers.loaders import SakuraCardLoader
+from crawlers.items import SakuraCardItem
+
+class SakuraCardsSpider(scrapy.Spider):
+    name = 'sakura-cards'
+    start_urls = ['https://ccsakura.fandom.com/wiki/Clow_Cards']
+
+    def parse(self, response):
+        metadata = {'card_type': 'Sakura Card'}
+        card_urls = response.xpath(ccs.CARD_PAGE).getall()
+        
+        for url in card_urls:
+            yield response.follow(url=url, callback=self.parse_card, meta=metadata)
+    
+    def parse_card(self, response):
+        loader = SakuraCardLoader(item=SakuraCardItem(), response=response)
+
+        loader.add_xpath('card', ccs.NAME)
+        loader.add_value('card_type', response.meta.get('card_type'))
+        loader.add_xpath('img_url', ccs.IMAGE_URL)
+        loader.add_xpath('sign', ccs.SIGN)
+        loader.add_xpath('hierarchy', ccs.HIEGHERARCHY)
+        loader.add_xpath('magic_type', ccs.MAGIC_TYPE)
+
+        return loader.load_item()

--- a/crawlers/spiders/selectors/sakura_cards_selectors.py
+++ b/crawlers/spiders/selectors/sakura_cards_selectors.py
@@ -1,0 +1,12 @@
+CARD_PAGE = '//div[@class="lightbox-caption"]/a/@href'
+
+NAME = '//*[@id="PageHeader"]/div[1]/h1/text()'
+
+IMAGE_URL = '//*[@id="pi-tab-1"]/figure/a/img/@src'
+
+SIGN = '//*[@id="mw-content-text"]/aside/div[2]/div/a/text()'
+
+# This doesn't match anything, but leaving it here for historical purposes
+HIEGHERARCHY = '//table[@class="infobox"]//tr[4]//a/text() | //table[@class="infobox"]//tr[4]/td[2]/text()'
+
+MAGIC_TYPE = '//*[@id="mw-content-text"]/aside/div[3]/div/text()'


### PR DESCRIPTION
Added a new spider to pull the Sakura cards.

` $ scrapy crawl sakura-cards -o /tmp/out.json`

Edited all xpath selectors to match new page format. 

Note: existing clow spider is probably broken, when run according to the readme it didn't correctly extract card details. I believe the xpath expressions in the selector are incorrect.

Note 2: I wasn't able to `hierarchy`, I don't think it's shown on the page.